### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Enable gmp, gd, soap, mbstring, pdo and pdo-mysql.
 
  - Download project & unzip.
  - Go to `application/config/` folder and change `config.php.sample` file name to `config.php`
- - Open the config file and set your server data.
+ - Open the config file and set your server data. If the "Image Captcha" type is used, then the GD2 module for PHP must be installed.
  - Enjoy that.
 
 # Debug


### PR DESCRIPTION
If the "Image Captcha" type is used, then the GD2 module for PHP must be installed.

Otherwise, the page will not load and the user will receive an error: "Fatal error: Uncaught Error: Call to undefined function Gregwar \ Captcha \ imagecreatetruecolor".

I think this information is important, we can add this information to the config.